### PR TITLE
Implement context manager API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,62 +20,71 @@ $ pip install ngenicpy
 import json
 
 from ngenicpy import Ngenic
-ng = Ngenic(token="YOUR-API-TOKEN")
 
-tunes = ng.tunes()
-for tune in tunes:
-    print("Tune %s\nName: %s\nTune Name: %s" %
-            (
-                tune.uuid(),
-                tune["name"],
-                tune["tuneName"]
-            )
-    )
-
-tune = ng.tune("TUNE-UUID")
-
-rooms = tune.rooms()
-for room in rooms:
-    print("Room %s\nName: %s\nTarget Temperature: %d" %
-            (
-                room.uuid(),
-                room["name"],
-                room["targetTemperature"]
-            )
-    )
-
-# Update a room
-room = tune.room(roomUuid="ROOM-UUID")
-room["name"] = "Livingroom"
-room.update()
-
-nodes = tune.nodes()
-for node in nodes:
-    node_status = node.status()
-
-    print("Node %s\nType: %s" %
-            (
-                node.uuid(),
-                node.get_type()
-            )
-    )
-
-    if node_status:
-        print("Battery: %s\%\nRadio Signal: %s" %
+# try/finally
+try:
+    ngenic = Ngenic(token="YOUR-API-TOKEN")
+except NgenicException as e:
+        print(str(e))
+finally:
+    ngenic.close()
+    
+# as context manager
+with Ngenic(token="YOUR-API-TOKEN") as ngenic:
+    tunes = ngenic.tunes()
+    for tune in tunes:
+        print("Tune %s\nName: %s\nTune Name: %s" %
                 (
-                    str(node_status.battery_percentage()),
-                    str(node_status.radio_signal_percentage())
+                    tune.uuid(),
+                    tune["name"],
+                    tune["tuneName"]
                 )
         )
 
-    measurements = node.measurements()
-    for measurement in measurements:
-        print("%s: %d" %
+    tune = ngenic.tune("TUNE-UUID")
+
+    rooms = tune.rooms()
+    for room in rooms:
+        print("Room %s\nName: %s\nTarget Temperature: %d" %
                 (
-                    measurement.get_type(),
-                    measurement["value"]
+                    room.uuid(),
+                    room["name"],
+                    room["targetTemperature"]
                 )
         )
+
+    # Update a room
+    room = tune.room(roomUuid="ROOM-UUID")
+    room["name"] = "Livingroom"
+    room.update()
+
+    nodes = tune.nodes()
+    for node in nodes:
+        node_status = node.status()
+
+        print("Node %s\nType: %s" %
+                (
+                    node.uuid(),
+                    node.get_type()
+                )
+        )
+
+        if node_status:
+            print("Battery: %s\nRadio Signal: %s" %
+                    (
+                        str(node_status.battery_percentage()),
+                        str(node_status.radio_signal_percentage())
+                    )
+            )
+
+        measurements = node.measurements()
+        for measurement in measurements:
+            print("%s: %d" %
+                    (
+                        measurement.get_type(),
+                        measurement["value"]
+                    )
+            )
 ```
 
 Async example
@@ -83,17 +92,17 @@ Async example
 import json
 
 from ngenicpy import Ngenic
-ng = Ngenic(token="YOUR-API-TOKEN")
 
-tunes = await ng.async_tunes()
-for tune in tunes:
-    print("Tune %s\nName: %s\nTune Name: %s" %
-            (
-                tune.uuid(),
-                tune["name"],
-                tune["tuneName"]
-            )
-    )
+async with AsyncNgenic(token="YOUR-API-TOKEN") as ngenic:
+    tunes = await ngenic.async_tunes()
+    for tune in tunes:
+        print("Tune %s\nName: %s\nTune Name: %s" %
+                (
+                    tune.uuid(),
+                    tune["name"],
+                    tune["tuneName"]
+                )
+        )
 ```
 
 ## Reference

--- a/ngenicpy/__init__.py
+++ b/ngenicpy/__init__.py
@@ -1,2 +1,2 @@
-from .ngenic import Ngenic
+from .ngenic import Ngenic, AsyncNgenic
 from .exceptions import ApiException, ClientException

--- a/ngenicpy/models/measurement.py
+++ b/ngenicpy/models/measurement.py
@@ -13,11 +13,11 @@ class MeasurementType(Enum):
     ENERGY_KWH = "energi_kWH"
 
 class Measurement(NgenicBase):
-    def __init__(self, token, json, node, measurement_type):
+    def __init__(self, session, json, node, measurement_type):
         self._parentNode = node
         self._measurementType = measurement_type
 
-        super(Measurement, self).__init__(token, json)
+        super(Measurement, self).__init__(session=session, json=json)
 
     def get_type(self):
         """Get the measurement type

--- a/ngenicpy/models/node_status.py
+++ b/ngenicpy/models/node_status.py
@@ -3,10 +3,10 @@ from .base import NgenicBase
 from ..const import API_PATH
 
 class NodeStatus(NgenicBase):
-    def __init__(self, token, json, node):
+    def __init__(self, session, json, node):
         self._parentNode = node
 
-        super(NodeStatus, self).__init__(token, json)
+        super(NodeStatus, self).__init__(session=session, json=json)
 
     def battery_percentage(self):
         if self["maxBattery"] == 0:

--- a/ngenicpy/models/room.py
+++ b/ngenicpy/models/room.py
@@ -3,10 +3,10 @@ from .base import NgenicBase
 from ..const import API_PATH
 
 class Room(NgenicBase):
-    def __init__(self, token, json, tune):
+    def __init__(self, session, json, tune):
         self._parentTune = tune
 
-        super(Room, self).__init__(token, json)
+        super(Room, self).__init__(session=session, json=json)
 
     def update(self):
         """Update this room with its current values"""

--- a/ngenicpy/models/tune.py
+++ b/ngenicpy/models/tune.py
@@ -5,8 +5,8 @@ from .node import Node
 from ..const import API_PATH
 
 class Tune(NgenicBase):
-    def __init__(self, token, json):
-        super(Tune, self).__init__(token, json)
+    def __init__(self, session, json):
+        super(Tune, self).__init__(session=session, json=json)
 
     def uuid(self):
         """Get the tune UUID"""

--- a/ngenicpy/ngenic.py
+++ b/ngenicpy/ngenic.py
@@ -14,7 +14,7 @@ import httpx
 LOG = logging.getLogger(__package__)
 
 # 30sec for connect, 10sec elsewhere.
-timeout = httpx.Timeout(10.0, connect=2.0)
+timeout = httpx.Timeout(10.0, connect=20.0)
 
 class BaseClient(NgenicBase):
     def __init(self, session):

--- a/ngenicpy/ngenic.py
+++ b/ngenicpy/ngenic.py
@@ -9,12 +9,16 @@ from .exceptions import ApiException, ClientException
 
 import logging
 import json
+import httpx
 
 LOG = logging.getLogger(__package__)
 
-class Ngenic(NgenicBase):
-    def __init__(self, token):
-        super(Ngenic, self).__init__(token, json)
+# 30sec for connect, 10sec elsewhere.
+timeout = httpx.Timeout(10.0, connect=2.0)
+
+class BaseClient(NgenicBase):
+    def __init(self, session):
+        super(BaseClient, self).__init__(session=session)
 
     def tunes(self):
         """Fetch all tunes
@@ -63,3 +67,61 @@ class Ngenic(NgenicBase):
         """
         url = API_PATH["tunes"].format(tuneUuid=tuneUuid)
         return self._async_parse_new_instance(url, Tune)
+    
+class Ngenic(BaseClient):
+    def __init__(self, token):
+        """Initialize an ngenic object.
+
+        :param token:
+            (required) OAuth2 bearer token
+        """
+
+        # this will be added to the HTTP Authorization header for each request
+        self._token = token
+
+        # this header will be added to each HTTP request
+        self._auth_headers = {"Authorization": "Bearer %s" % self._token}
+
+        session = httpx.Client(headers=self._auth_headers, timeout=timeout) 
+
+        # initializing this doesn't require a session or json
+        super(Ngenic, self).__init__(session=session)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def close(self):
+        """Close the session if it was not created as a context manager"""
+        self._session.close()
+
+class AsyncNgenic(BaseClient):
+    def __init__(self, token):
+        """Initialize an async ngenic object.
+
+        :param token:
+            (required) OAuth2 bearer token
+        """
+
+        # this will be added to the HTTP Authorization header for each request
+        self._token = token
+
+        # this header will be added to each HTTP request
+        self._auth_headers = {"Authorization": "Bearer %s" % self._token}
+
+        session = httpx.AsyncClient(headers=self._auth_headers, timeout=timeout) 
+
+        # initializing this doesn't require a session or json
+        super(AsyncNgenic, self).__init__(session=session)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        await self.async_close()
+
+    async def async_close(self):
+        """Close the session if it was not created as a context manager"""
+        await self._session.aclose()


### PR DESCRIPTION
Instead of passing around the token and re-establish the connection all
the time, we now pass around a session (which is a httpx Client).
The httpx library will reuse connections made to the server, improving
API call times.

The library can now be used as a context manager, meaning underlying
httpx connections will be terminated automatically.

In case the library is used as before, `.close()` or `.async_close()`
needs to be called to cleanup the connections.

Other fixes:
* Fix incorrect examples in README
* Increase connection/request timeout
* A bit nicer logs for timeouts
* Don't fetch latest measurement for `ENERGY_KWH` when fetching all latest measurements (it's not supported)
  * Also fix the async variant of this method, which didn't gather the list correctly