### PR TITLE
Add missing MeasurementTypes

### DIFF
--- a/ngenicpy/models/measurement.py
+++ b/ngenicpy/models/measurement.py
@@ -10,7 +10,10 @@ class MeasurementType(Enum):
     HUMIDITY = "humidity_relative_percent"
     CONTROL_VALUE = "control_value_C"
     POWER_KW = "power_kW"
-    ENERGY_KWH = "energi_kWH"
+    ENERGY_KWH = "energy_kWH"
+    FLOW = "flow_litre_per_hour"
+    INLET_FLOW_TEMPERATURE = "inlet_flow_temperature_C"
+    RETURN_TEMPERATURE = "return_temperature_C"
 
 class Measurement(NgenicBase):
     def __init__(self, session, json, node, measurement_type):


### PR DESCRIPTION
The Ngenic API has been updated with more measurement types that are not present in the MeasurementType enum.
This closes sfalkman/ngenic-hass-platform#20 and closes sfalkman/ngenic-hass-platform#21